### PR TITLE
cupy submodule with example

### DIFF
--- a/src/cutqc2/cupy/simple/README.md
+++ b/src/cutqc2/cupy/simple/README.md
@@ -1,0 +1,7 @@
+The `main.cu` file is not technically needed, but serves to test the kernel
+in a standalone manner.
+
+```
+nvcc -o main main.cu -lcudart
+./main
+```

--- a/src/cutqc2/cupy/simple/__init__.py
+++ b/src/cutqc2/cupy/simple/__init__.py
@@ -1,0 +1,66 @@
+from pathlib import Path
+import numpy as np
+import cupy as cp
+
+
+def get_module():
+    # This operation is expensive - call it as few times as possible.
+    # We declare a global variable `cp_module` to store the compiled module.
+    with open(Path(__file__).parent / "simple.cu") as f:
+        code = f.read()
+    return cp.RawModule(code=code)
+
+
+cp_module = get_module()
+
+
+def matrix_add(a: np.array, b: np.array):
+    assert a.shape == b.shape
+    rows, cols = a.shape
+
+    matrix_add = cp_module.get_function("matrixAdd")
+    threads_per_block = 16, 16
+    blocks_per_grid = (
+        (rows + (threads_per_block[0] - 1)) // threads_per_block[0],
+        (cols + (threads_per_block[1] - 1)) // threads_per_block[1],
+    )
+
+    result = cp.zeros((rows, cols)).astype(a.dtype)
+    matrix_add(
+        blocks_per_grid,
+        threads_per_block,
+        (
+            cp.asarray(a),
+            cp.asarray(b),
+            cp.asarray(result),
+            np.int32(rows),
+            np.int32(cols),
+        ),
+    )
+    return cp.asnumpy(result)
+
+
+def matrix_subtract(a: np.array, b: np.array):
+    assert a.shape == b.shape
+    rows, cols = a.shape
+
+    matrix_add = cp_module.get_function("matrixSubtract")
+    threads_per_block = 16, 16
+    blocks_per_grid = (
+        (rows + (threads_per_block[0] - 1)) // threads_per_block[0],
+        (cols + (threads_per_block[1] - 1)) // threads_per_block[1],
+    )
+
+    result = cp.zeros((rows, cols)).astype(a.dtype)
+    matrix_add(
+        blocks_per_grid,
+        threads_per_block,
+        (
+            cp.asarray(a),
+            cp.asarray(b),
+            cp.asarray(result),
+            np.int32(rows),
+            np.int32(cols),
+        ),
+    )
+    return cp.asnumpy(result)

--- a/src/cutqc2/cupy/simple/main.cu
+++ b/src/cutqc2/cupy/simple/main.cu
@@ -1,0 +1,42 @@
+#include "simple.cu"
+#include <iostream>
+#include <cuda_runtime.h>
+
+
+int main() {
+    const int rows = 4;
+    const int cols = 4;
+    const int size = rows * cols * sizeof(float);
+
+    float h_A[rows * cols], h_B[rows * cols], h_C[rows * cols];
+    for (int i = 0; i < rows * cols; ++i) {
+        h_A[i] = i;
+        h_B[i] = i * 2;
+    }
+
+    float *d_A, *d_B, *d_C;
+    cudaMalloc((void**)&d_A, size);
+    cudaMalloc((void**)&d_B, size);
+    cudaMalloc((void**)&d_C, size);
+
+    cudaMemcpy(d_A, h_A, size, cudaMemcpyHostToDevice);
+    cudaMemcpy(d_B, h_B, size, cudaMemcpyHostToDevice);
+
+    dim3 threadsPerBlock(16, 16);
+    dim3 blocksPerGrid((cols + 15) / 16, (rows + 15) / 16);
+    matrixAdd<<<blocksPerGrid, threadsPerBlock>>>(d_A, d_B, d_C, rows, cols);
+
+    cudaMemcpy(h_C, d_C, size, cudaMemcpyDeviceToHost);
+
+    std::cout << "Result matrix C:\n";
+    for (int i = 0; i < rows * cols; ++i) {
+        std::cout << h_C[i] << " ";
+        if ((i + 1) % cols == 0) std::cout << "\n";
+    }
+
+    cudaFree(d_A);
+    cudaFree(d_B);
+    cudaFree(d_C);
+
+    return 0;
+}

--- a/src/cutqc2/cupy/simple/simple.cu
+++ b/src/cutqc2/cupy/simple/simple.cu
@@ -1,0 +1,19 @@
+extern "C" __global__ void matrixAdd(const float* A, const float* B, float* C, int rows, int cols) {
+    int row = blockIdx.y * blockDim.y + threadIdx.y;
+    int col = blockIdx.x * blockDim.x + threadIdx.x;
+
+    int idx = row * cols + col;
+    if (row < rows && col < cols) {
+        C[idx] = A[idx] + B[idx];
+    }
+}
+
+extern "C" __global__ void matrixSubtract(const float* A, const float* B, float* C, int rows, int cols) {
+    int row = blockIdx.y * blockDim.y + threadIdx.y;
+    int col = blockIdx.x * blockDim.x + threadIdx.x;
+
+    int idx = row * cols + col;
+    if (row < rows && col < cols) {
+        C[idx] = A[idx] - B[idx];
+    }
+}

--- a/tests/test_cupy.py
+++ b/tests/test_cupy.py
@@ -1,7 +1,9 @@
 from cutqc2.cupy.simple import matrix_add, matrix_subtract
 import numpy as np
+import pytest
 
 
+@pytest.mark.skip(reason="Cannot run on Github CI currently")
 def test_matrix_add():
     a = np.array([[0, 1, 2, 3], [4, 5, 6, 7]], dtype=np.float32)
     b = np.array([[0, 3, 6, 9], [12, 15, 18, 21]], dtype=np.float32)
@@ -10,6 +12,7 @@ def test_matrix_add():
     assert np.allclose(result, expected)
 
 
+@pytest.mark.skip(reason="Cannot run on Github CI currently")
 def test_matrix_subtract():
     a = np.array([[0, 1, 2, 3], [4, 5, 6, 7]], dtype=np.float32)
     b = np.array([[0, 3, 6, 9], [12, 15, 18, 21]], dtype=np.float32)

--- a/tests/test_cupy.py
+++ b/tests/test_cupy.py
@@ -1,0 +1,18 @@
+from cutqc2.cupy.simple import matrix_add, matrix_subtract
+import numpy as np
+
+
+def test_matrix_add():
+    a = np.array([[0, 1, 2, 3], [4, 5, 6, 7]], dtype=np.float32)
+    b = np.array([[0, 3, 6, 9], [12, 15, 18, 21]], dtype=np.float32)
+    expected = a + b
+    result = matrix_add(a, b)
+    assert np.allclose(result, expected)
+
+
+def test_matrix_subtract():
+    a = np.array([[0, 1, 2, 3], [4, 5, 6, 7]], dtype=np.float32)
+    b = np.array([[0, 3, 6, 9], [12, 15, 18, 21]], dtype=np.float32)
+    expected = a - b
+    result = matrix_subtract(a, b)
+    assert np.allclose(result, expected)


### PR DESCRIPTION
I've added a simple example of a cuda kernel and its usage from our `cutqc2` module, along with a test. This should give us a pattern to extend over time.