### PR TITLE
Support for multiple Pauli bases in get_initializations

### DIFF
--- a/src/cutqc2/core/cut_circuit.py
+++ b/src/cutqc2/core/cut_circuit.py
@@ -200,37 +200,31 @@ class CutCircuit:
         trace operators for each of the Pauli bases (eq. 2 in paper).
 
                  0   1   +   i
+            0    1
             I    1   1
             X   -1  -1   2
             Y   -1  -1       2
             Z    1  -1
+
         """
         terms = {
+            "zero": {"zero": 1},
             "I": {"zero": 1, "one": 1},
             "X": {"zero": -1, "one": -1, "plus": 2},
             "Y": {"zero": -1, "one": -1, "plusI": 2},
             "Z": {"zero": 1, "one": -1},
         }
 
+        substitution_lists = [terms[pauli].items() for pauli in paulis]
+
         result = []
-        pauli_base_found = False
-        for i, pauli in enumerate(paulis):
-            if pauli in terms:
-                if pauli_base_found:
-                    raise ValueError("Use of multiple Pauli bases is not supported")
-
-                pauli_base_found = True
-                for ket, coeff in terms[pauli].items():
-                    # create a tuple of paulis, replacing the pauli at index i with ket
-                    bases = tuple(
-                        [ket if j == i else pauli for j, pauli in enumerate(paulis)]
-                    )
-                    result.append((coeff, bases))
-
-        if not pauli_base_found:
-            # If no Pauli base was found, return the original initialization
-            result.append((1, tuple(paulis)))
-
+        for combo in itertools.product(*substitution_lists):
+            coeff = 1
+            labels = []
+            for label, c in combo:
+                coeff *= c
+                labels.append(label)
+            result.append((coeff, tuple(labels)))
         return result
 
     def find_cuts(

--- a/tests/test_subcircuit_combinations.py
+++ b/tests/test_subcircuit_combinations.py
@@ -2,16 +2,16 @@ from cutqc2.core.cut_circuit import CutCircuit
 
 """
 The coefficients and kets used for each term in the expansion of the trace
-operators for each of the Pauli bases are (eq. 2 in paper):
+operators for each of the Pauli bases are (eq. 2 in paper).
+The "0" is a placeholder initializer, which results in no substitution.
 
      0   1   +   i
+0    1     
 I    1   1
 X   -1  -1   2
 Y   -1  -1       2
 Z    1  -1
 
-For the tests below, only one of the initializations are not "zero". Results
-may not make sense if >1 initialization is not "zero" (TODO: Confirm this).
 """
 
 
@@ -72,3 +72,21 @@ def testZ():
     # kets should populate at the location of the Pauli basis
     assert (1, ("zero", "zero", "zero", "zero")) in coeffs_kets
     assert (-1, ("zero", "zero", "one", "zero")) in coeffs_kets
+
+
+def testIzeroX():
+    # The input bases can contain multiple Pauli bases
+    initializations = ["I", "zero", "X"]
+    coeffs_kets = CutCircuit.get_initializations(initializations)
+
+    # important - don't rely on the order in which the coefficients and kets
+    # are returned, but simply assert they're there.
+    assert len(coeffs_kets) == 6
+    # kets should populate at the location of the Pauli bases, and the
+    # coefficients multiplied together.
+    assert (2, ("zero", "zero", "plus")) in coeffs_kets
+    assert (-1, ("zero", "zero", "zero")) in coeffs_kets
+    assert (-1, ("zero", "zero", "one")) in coeffs_kets
+    assert (2, ("one", "zero", "plus")) in coeffs_kets
+    assert (-1, ("one", "zero", "zero")) in coeffs_kets
+    assert (-1, ("one", "zero", "one")) in coeffs_kets


### PR DESCRIPTION
The adder circuit revealed (and you pointed out explicitly) that initializations of a subcircuit will typically have multiple Pauli bases indicators, not necessarily just one. I've taken off this restriction in the refactored code and added a test for this.