### PR TITLE
Supremacy circuit bug fix

### DIFF
--- a/src/cutqc2/core/cut_circuit.py
+++ b/src/cutqc2/core/cut_circuit.py
@@ -473,15 +473,26 @@ class CutCircuit:
                         prev_subcircuit_i is not None
                         and prev_subcircuit_i != subcircuit_i
                     ):
-                        # For the existing ("current") subcircuit on this wire,
+                        # For the previous subcircuit on this wire,
                         # add a new qubit wire for this wire index.
                         subcircuit_wire_index = next_subcircuit_wire_index[
                             prev_subcircuit_i
                         ]
+
+                        # Find all used subcircuit qubits in the previous subcircuit.
+                        prev_subcircuit_used_wires = [
+                            j
+                            for wires in subcircuit_map[prev_subcircuit_i].values()
+                            for j in wires
+                        ]
+                        # If the previous subcircuit has used this qubit,
+                        # make room for more.
+                        if subcircuit_wire_index in prev_subcircuit_used_wires:
+                            next_subcircuit_wire_index[prev_subcircuit_i] += 1
+
                         subcircuit_map[prev_subcircuit_i][wire_index].append(
                             subcircuit_wire_index
                         )
-                        next_subcircuit_wire_index[prev_subcircuit_i] += 1
 
                     current_subciruit_on_wire[wire_index] = subcircuit_i
 

--- a/tests/test_cut_verify.py
+++ b/tests/test_cut_verify.py
@@ -43,3 +43,38 @@ def test_figure4_verify(figure_4_qiskit_circuit):
     cut_circuit.run_subcircuits()
     cut_circuit.postprocess()
     cut_circuit.verify()
+
+
+def test_supremacy_verify():
+    num_qubits = 6
+    circuit = generate_circ(
+        num_qubits=num_qubits,
+        depth=1,
+        circuit_type="supremacy",
+        reg_name="q",
+        connected_only=True,
+        seed=None,
+    )
+    import math
+
+    cutter_constraints = {
+        "max_subcircuit_width": math.ceil(circuit.num_qubits / 4 * 3),
+        "max_subcircuit_cuts": 10,
+        "subcircuit_size_imbalance": 2,
+        "max_cuts": 10,
+        "num_subcircuits": [3],
+    }
+
+    cut_circuit = CutCircuit(circuit)
+
+    cut_circuit.cut(
+        max_subcircuit_width=cutter_constraints["max_subcircuit_width"],
+        max_subcircuit_cuts=cutter_constraints["max_subcircuit_cuts"],
+        subcircuit_size_imbalance=cutter_constraints["subcircuit_size_imbalance"],
+        max_cuts=cutter_constraints["max_cuts"],
+        num_subcircuits=cutter_constraints["num_subcircuits"],
+    )
+
+    cut_circuit.run_subcircuits()
+    cut_circuit.postprocess()
+    cut_circuit.verify()

--- a/tests/test_cut_verify.py
+++ b/tests/test_cut_verify.py
@@ -2,6 +2,7 @@
 Tests for end-end verification of cut circuits.
 """
 
+import math
 from cutqc2.cutqc.helper_functions.benchmarks import generate_circ
 from cutqc2.core.cut_circuit import CutCircuit
 
@@ -46,33 +47,22 @@ def test_figure4_verify(figure_4_qiskit_circuit):
 
 
 def test_supremacy_verify():
-    num_qubits = 6
     circuit = generate_circ(
-        num_qubits=num_qubits,
+        num_qubits=6,
         depth=1,
         circuit_type="supremacy",
         reg_name="q",
         connected_only=True,
         seed=None,
     )
-    import math
-
-    cutter_constraints = {
-        "max_subcircuit_width": math.ceil(circuit.num_qubits / 4 * 3),
-        "max_subcircuit_cuts": 10,
-        "subcircuit_size_imbalance": 2,
-        "max_cuts": 10,
-        "num_subcircuits": [3],
-    }
 
     cut_circuit = CutCircuit(circuit)
-
     cut_circuit.cut(
-        max_subcircuit_width=cutter_constraints["max_subcircuit_width"],
-        max_subcircuit_cuts=cutter_constraints["max_subcircuit_cuts"],
-        subcircuit_size_imbalance=cutter_constraints["subcircuit_size_imbalance"],
-        max_cuts=cutter_constraints["max_cuts"],
-        num_subcircuits=cutter_constraints["num_subcircuits"],
+        max_subcircuit_width=math.ceil(circuit.num_qubits / 4 * 3),
+        max_subcircuit_cuts=10,
+        subcircuit_size_imbalance=2,
+        max_cuts=10,
+        num_subcircuits=[3],
     )
 
     cut_circuit.run_subcircuits()


### PR DESCRIPTION
A minor tweak to the subcircuit instruction generation algorithm helps us fix the bug found in the supremacy circuit.

The core problem was that by always introducing a qubit when we encounter a cut on a wire (on the subcircuit we last saw on that wire), we end up in a situation like this:
```
     ┌───┐   ┌─────────┐┌───┐   ┌─────────┐┌───┐┌───┐
q_0: ┤ H ├─■─┤ Rx(π/2) ├┤ T ├─■─┤ Ry(π/2) ├┤ T ├┤ H ├
     ├───┤ │ ├─────────┤├───┤ │ └─────────┘├───┤└───┘
q_1: ┤ H ├─■─┤ Ry(π/2) ├┤ T ├─┼──────■─────┤ H ├─────
     └───┘   └─────────┘└───┘ │      │     └───┘     
q_2: ─────────────────────────■──────┼───────────────
                                     │               
q_3: ────────────────────────────────┼───────────────
                                     │     ┌───┐     
q_4: ────────────────────────────────■─────┤ H ├─────
                                           └───┘     
                                           
```
This makes the no. of "effective" qubits in that subcircuit one more than it should be, and the effects are felt way downstream.